### PR TITLE
fix Travis build : modify jdk to use openjdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: java
-jdk: oraclejdk8
+jdk: openjdk8


### PR DESCRIPTION
Fix/travis build jdk
Replace Oracle jdk by open jdk